### PR TITLE
[Chore] 프리패칭 없는 실험적 스트리밍 라이브러리 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@tanstack/react-query": "^5.53.1",
     "@tanstack/react-query-devtools": "^5.53.1",
-    "@tanstack/react-query-next-experimental": "^5.53.1",
     "axios": "^1.7.5",
     "next": "14.2.7",
     "react": "^18",

--- a/src/components/providers/ReactQuery.tsx
+++ b/src/components/providers/ReactQuery.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental';
 
 export default function ReactQueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -18,7 +17,7 @@ export default function ReactQueryProvider({ children }: { children: React.React
   return (
     <QueryClientProvider client={queryClient}>
       {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
-      <ReactQueryStreamedHydration>{children}</ReactQueryStreamedHydration>
+      {children}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 🚨 관련 이슈
#6 
  
## ✨ 작업 내용
- @tanstack/react-query-next-experimental (프리패칭 없는 실험적 스트리밍) 을 제거합니다.
- 이 패키지를 사용하면 구성 요소에서 useSuspenseQuery를 호출하기만 하면 서버(클라이언트 구성 요소)에서 데이터를 패치할 수 있습니다. 즉, SSR(서버측 렌더링) 애플리케이션에서 데이터 가져오기 및 렌더링 성능을 향상시키기 위해 해당 라이브러리를 사용하고자 하였습니다.
- 아래와 같은 이유로 해당 라이브러리를 제거하고자 합니다.
	1) "실험적"이라는 레이블이 붙은 만큼, 라이브러리가 아직 개발 중이기 때문에 충분히 안정적이지 않으며, 
	2) 현재 픽스된 기획 내에서는 고도로 최적화된 SSR 성능이 필요하지 않기 때문에, 해당 라이브러리의 이점은 절충할만한 가치가 없는 것으로 판단됩니다.
  
  
## 💁‍♀️ 참고 사항
- [공식 Docs](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr#experimental-streaming-without-prefetching-in-nextjs)

  
## 🤔 논의 사항
- feat 외 초기 세팅을 건드는 커밋에 대해서 어떤 prefix를 사용해야 하는지 판단이 서지 않았습니다.
- ~~우선 기능 구현이 되지 않았고, 초기 세팅을 수정하는 것이기 때문에 init prefix를 택했는데, 맞는 선택이었는지 논의하고 싶습니다..~~
- chore prefix로 수정하였습니다.

  


  
