### PR TITLE
[Bug] 메인 페이지 로드 시, 카로셀 크기가 비좁게 출력되는 문제

### DIFF
--- a/src/pages/main/component/banner-carousel/style.module.scss
+++ b/src/pages/main/component/banner-carousel/style.module.scss
@@ -43,6 +43,8 @@
   white-space: pre-wrap;
   position: absolute;
   width: 100%;
+  min-width: 328px;
+
   bottom: 42px;
   z-index: 10;
 }


### PR DESCRIPTION
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다. -->
[[Bug] 메인 페이지 로드 시, 카로셀 크기가 비좁게 출력되는 문제 #84](https://github.com/Spoon-Lab/our-journey-fe/issues/84)
  
## ✨ 작업 내용
<!-- 어떤 작업을 하셨는지 내용을 작성해주세요. -->
<!-- 작업된 화면이나 작업 전 후의 비교 이미지가 있으면 더더욱 좋아요. -->
- 검색어를 입력할 때 띄어쓰기가 반영되는 부분이 있어, 검색할 때 _가 붙여지도록 수정했습니다.
- 메인 페이지 로드 중에, 이제 검색어가 비좁아진 상태로 노출되는 부분이 사라집니다.

## 💁‍♀️ 참고 사항
<!-- 작업하면서 참고하셨던 사항이 있거나, 읽으셨던 문서 등이 있으셨다면 여기에 남겨주세요. -->
<!-- 동료들에게 좋은 지식을 전파할 수 있는 기회에요 :D -->
  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->