### PR TITLE
[Bug] 로컬스토리지에 남아있는 경우 리프레시토큰 자동 발급 에러

### DIFF
--- a/src/hooks/auth/use-email-request.ts
+++ b/src/hooks/auth/use-email-request.ts
@@ -5,12 +5,12 @@ import { useRouter } from 'next/router';
 import { API_PATHS } from '@/constants/api';
 import { ROUTES } from '@/constants/router';
 
-import axiosAuthInstance from '@/libs/auth-axios';
+import { axiosBasicAuthInstance } from '@/libs/auth-axios';
 
 import { useToast } from '../use-toast';
 
 const requestEmail = async ({ email }: { email: string }) => {
-  const res = await axiosAuthInstance.post(`${API_PATHS.AUTH.PASSWORD.RESET.POST()}`, {
+  const res = await axiosBasicAuthInstance.post(`${API_PATHS.AUTH.PASSWORD.RESET.POST()}`, {
     email,
   });
 

--- a/src/hooks/auth/use-login.ts
+++ b/src/hooks/auth/use-login.ts
@@ -6,12 +6,12 @@ import type { Login, LoginResponse } from '@/types/auth';
 import { API_PATHS } from '@/constants/api';
 import { ROUTES } from '@/constants/router';
 
-import axiosAuthInstance from '@/libs/auth-axios';
+import { axiosBasicAuthInstance } from '@/libs/auth-axios';
 
 import { useToast } from '../use-toast';
 
 const login = async ({ email, password }: Login) => {
-  const { data } = await axiosAuthInstance.post<LoginResponse>(`${API_PATHS.AUTH.LOGIN.POST()}`, { email, password });
+  const { data } = await axiosBasicAuthInstance.post<LoginResponse>(`${API_PATHS.AUTH.LOGIN.POST()}`, { email, password });
 
   return data;
 };

--- a/src/hooks/auth/use-reset-password.ts
+++ b/src/hooks/auth/use-reset-password.ts
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { API_PATHS } from '@/constants/api';
 import { ROUTES } from '@/constants/router';
 
-import axiosAuthInstance from '@/libs/auth-axios';
+import { axiosBasicAuthInstance } from '@/libs/auth-axios';
 
 import { useToast } from '../use-toast';
 
@@ -17,7 +17,7 @@ interface ResetPasswordProps {
 }
 
 const resetPassword = async ({ uid64, token, new_password1, new_password2 }: ResetPasswordProps) => {
-  const res = await axiosAuthInstance.post(`${API_PATHS.AUTH.PASSWORD.CHANGE.POST(uid64, token)}`, {
+  const res = await axiosBasicAuthInstance.post(`${API_PATHS.AUTH.PASSWORD.CHANGE.POST(uid64, token)}`, {
     new_password1,
     new_password2,
   });

--- a/src/hooks/auth/use-signup.ts
+++ b/src/hooks/auth/use-signup.ts
@@ -6,12 +6,12 @@ import type { Signup } from '@/types/auth';
 import { API_PATHS } from '@/constants/api';
 import { ROUTES } from '@/constants/router';
 
-import axiosAuthInstance from '@/libs/auth-axios';
+import { axiosBasicAuthInstance } from '@/libs/auth-axios';
 
 import { useToast } from '../use-toast';
 
 const signup = async ({ email, password1, password2 }: Signup) => {
-  const res = await axiosAuthInstance.post(`${API_PATHS.AUTH.SIGNUP.POST()}`, { email, password1, password2 });
+  const res = await axiosBasicAuthInstance.post(`${API_PATHS.AUTH.SIGNUP.POST()}`, { email, password1, password2 });
 
   return res;
 };

--- a/src/libs/auth-axios.ts
+++ b/src/libs/auth-axios.ts
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query';
 import type { AxiosError, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 
@@ -16,6 +15,13 @@ const axiosConfig = {
 };
 
 const axiosAuthInstance = axios.create(axiosConfig);
+
+export const axiosRefreshInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_AUTH_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
 
 axiosAuthInstance.interceptors.request.use(
   (config) => {
@@ -42,7 +48,7 @@ axiosAuthInstance.interceptors.response.use(
 
       if (refresh) {
         try {
-          const { data } = await axiosAuthInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
+          const { data } = await axiosRefreshInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
 
           if (data?.access) {
             localStorage.setItem('accessToken', data.access);
@@ -54,11 +60,7 @@ axiosAuthInstance.interceptors.response.use(
             return axiosAuthInstance(originalConfig);
           }
         } catch (refreshError) {
-          const queryClient = useQueryClient();
-
-          // TODO:로그아웃 처리?
           localStorage.clear();
-          queryClient.clear();
           window.location.href = '/login';
         }
       }

--- a/src/libs/auth-axios.ts
+++ b/src/libs/auth-axios.ts
@@ -16,7 +16,8 @@ const axiosConfig = {
 
 const axiosAuthInstance = axios.create(axiosConfig);
 
-export const axiosRefreshInstance = axios.create({
+// token이 헤더에 들어가지 않는 인스턴스 입니다
+export const axiosBasicAuthInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_AUTH_URL,
   headers: {
     'Content-Type': 'application/json',
@@ -48,7 +49,7 @@ axiosAuthInstance.interceptors.response.use(
 
       if (refresh) {
         try {
-          const { data } = await axiosRefreshInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
+          const { data } = await axiosBasicAuthInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
 
           if (data?.access) {
             localStorage.setItem('accessToken', data.access);

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 
 import { API_PATHS } from '@/constants/api';
 
-import { axiosRefreshInstance, type CustomAxiosRequestConfig } from './auth-axios';
+import { axiosBasicAuthInstance, type CustomAxiosRequestConfig } from './auth-axios';
 
 const axiosConfig = {
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -41,7 +41,7 @@ axiosInstance.interceptors.response.use(
 
       if (refresh) {
         try {
-          const { data } = await axiosRefreshInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
+          const { data } = await axiosBasicAuthInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
 
           if (data?.access) {
             localStorage.setItem('accessToken', data.access);

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,13 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import axios from 'axios';
 
 import { API_PATHS } from '@/constants/api';
 
-import type { CustomAxiosRequestConfig } from './auth-axios';
-import axiosAuthInstance from './auth-axios';
+import { axiosRefreshInstance, type CustomAxiosRequestConfig } from './auth-axios';
 
 const axiosConfig = {
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -43,7 +41,7 @@ axiosInstance.interceptors.response.use(
 
       if (refresh) {
         try {
-          const { data } = await axiosAuthInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
+          const { data } = await axiosRefreshInstance.post<{ access: string }>(`${API_PATHS.AUTH.TOKEN.REFRESH.POST()}`, { refresh });
 
           if (data?.access) {
             localStorage.setItem('accessToken', data.access);
@@ -55,11 +53,7 @@ axiosInstance.interceptors.response.use(
             return axiosInstance(originalConfig);
           }
         } catch (refreshError) {
-          const queryClient = useQueryClient();
-
-          // TODO:로그아웃 처리?
           localStorage.clear();
-          queryClient.clear();
           window.location.href = '/login';
         }
       }


### PR DESCRIPTION
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다. -->

#94 
  
## ✨ 작업 내용
<!-- 어떤 작업을 하셨는지 내용을 작성해주세요. -->
<!-- 작업된 화면이나 작업 전 후의 비교 이미지가 있으면 더더욱 좋아요. -->

이슈 내용을 참고해주세요 ! 
로그아웃을 누르지 않고 다음날에 들어가면 이미 로컬스토리지에 토큰값이 들어가있어 
로그인을 다시 하려고하면 401에러가 뜨는 경우가 있습니다.

-> 이때 다시 리프레시토큰으로 토큰을 갱신하려고하는데 
이부분에서 제가 자동 인터셉트되는 axios인스턴스를 사용해서 401 무한루프에 빠지게 되었습니다.
이를 수정하기 위해 토큰이 들어가지 않는 다른 인스턴스를 만들었고, 여기서 리프레시 토큰을 수행하니 401에러가 뜰경우 자동 로그아웃이 됩니다.

-> 이부분을 수정하고나니, 회원가입 로그인시 (로컬스토리지에 토큰이 들어가있을때) 401에러가 뜨면 리프레시토큰으로 토큰을 재발급 받는 로직이 수행이 되는데 사실 회원가입이나 로그인은 헤더에 토큰이 필요하지 않는 요청이므로 리프레시토큰을 불러오는 인스턴스와 동일한 axios를 변경했습니다

- axiosBasicAuthInstance 이름으로 토큰이 자동으로 들어가지 않는 인스턴스를 생성해 로그인/회원가입/리프레시토큰 로직 등에 추가하였습니다.

  
## 💁‍♀️ 참고 사항
<!-- 작업하면서 참고하셨던 사항이 있거나, 읽으셨던 문서 등이 있으셨다면 여기에 남겨주세요. -->
<!-- 동료들에게 좋은 지식을 전파할 수 있는 기회에요 :D -->



  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->

지금 jwt를 로컬스토리지에 저장하다보니 생기는 문제같기도합니다.
따라서 2차 때 쿠키에 저장할 수 있도록 찾아보고 
전반적으로 변경하도록 하겠습니다 ! 


  
