### PR TITLE
[Bug] 메인 레이아웃 grid max width 조절

### DIFF
--- a/src/components/feed-grid/style.module.scss
+++ b/src/components/feed-grid/style.module.scss
@@ -1,6 +1,6 @@
 .feedWrapper {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(calc(50% - 4px), 1fr));
   gap: 14px 8px;
   overflow-y: auto;
   width: 100%;


### PR DESCRIPTION
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다. -->
  메인 grid 레이아웃에서 grid width가 화면을 넘기는 문제가 있었습니다.

## ✨ 작업 내용
<!-- 어떤 작업을 하셨는지 내용을 작성해주세요. -->
<!-- 작업된 화면이나 작업 전 후의 비교 이미지가 있으면 더더욱 좋아요. -->
```scss
 grid-template-columns: repeat(auto-fit, minmax(calc(50% - 4px), 1fr));
```
  상위 요소의 너비에 맞추도록 코드를 수정하였습니다.
  
## 💁‍♀️ 참고 사항
<!-- 작업하면서 참고하셨던 사항이 있거나, 읽으셨던 문서 등이 있으셨다면 여기에 남겨주세요. -->
<!-- 동료들에게 좋은 지식을 전파할 수 있는 기회에요 :D -->

  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->

  


  
