### PR TITLE
[Feat] 상대방 프로필 화면 구현

### DIFF
--- a/src/constants/router.ts
+++ b/src/constants/router.ts
@@ -22,6 +22,8 @@ export const ROUTES = {
   },
   google: '/login/google',
   needLogin: '/need-login',
+
+  otherProfile: (id: number) => `/profile/${id}`,
 };
 
 export type ROUTES = (typeof ROUTES)[keyof typeof ROUTES];

--- a/src/hooks/profile/use-get-other-profile.ts
+++ b/src/hooks/profile/use-get-other-profile.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import type { Profile } from '@/types/profile';
+
+import { getOtherProfile } from '@/libs/auth-service';
+
+export default function useGetOtherProfile(id: number) {
+  const { data, isPending, isSuccess, error } = useQuery<Profile, AxiosError>({
+    queryKey: ['profile', id],
+    queryFn: () => getOtherProfile(id),
+    enabled: !!id,
+    staleTime: 60 * 1000 * 30,
+  });
+  return { data, isPending, isSuccess, error };
+}

--- a/src/libs/auth-service.ts
+++ b/src/libs/auth-service.ts
@@ -1,0 +1,9 @@
+import type { Profile } from '@/types/profile';
+import { API_PATHS } from '@/constants/api';
+
+import axiosInstance from './axios';
+
+export const getOtherProfile = async <T = Profile>(id: number): Promise<T> => {
+  const response = await axiosInstance.get<T>(API_PATHS.PROFILES.GET(id));
+  return response.data;
+};

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -55,7 +55,6 @@ axiosInstance.interceptors.response.use(
             return axiosInstance(originalConfig);
           }
         } catch (refreshError) {
-          // TODO:로그아웃 처리?
           localStorage.clear();
           window.location.href = '/login';
           return Promise.reject(refreshError);

--- a/src/pages/content/[contentId]/(components)/content-cover/index.tsx
+++ b/src/pages/content/[contentId]/(components)/content-cover/index.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 
 import type { Content, ContentWriterDto } from '@/types/threads';
+import { ROUTES } from '@/constants/router';
 
 import { formatTimeStamp } from '@/utils/format-date-timestamp';
 
@@ -15,7 +17,8 @@ interface ContentCoverProps {
 
 export default function ContentCover({ content, user }: ContentCoverProps) {
   const { title, postImg, createdAt } = content || {};
-  const { profileImgUrl, name } = user || {};
+  const { profileImgUrl, name, profileId } = user || {};
+  const router = useRouter();
 
   return (
     <div className={s.contentCover}>
@@ -26,7 +29,7 @@ export default function ContentCover({ content, user }: ContentCoverProps) {
           </div>
           <div className={s.contentInfo}>
             <div className={s.contentTitle}>{title || 'No data'}</div>
-            <div className={s.writerInfo}>
+            <button className={s.writerInfo} onClick={() => router.push(ROUTES.otherProfile(profileId))} type="button" aria-label="프로필 보기">
               <div className={s.profileImage}>
                 {profileImgUrl ? (
                   <Image src={profileImgUrl} alt="profile-image" width={40} height={40} />
@@ -35,7 +38,7 @@ export default function ContentCover({ content, user }: ContentCoverProps) {
                 )}
               </div>
               <span className={s.writerName}>{name}</span>
-            </div>
+            </button>
           </div>
         </div>
         <div className={s.imageWrapper}>

--- a/src/pages/content/[contentId]/(components)/thread-frame/index.tsx
+++ b/src/pages/content/[contentId]/(components)/thread-frame/index.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import type { Tag } from '@/types/threads';
+import { ROUTES } from '@/constants/router';
 
 import { checkValidImgUrl } from '@/utils/check-valid-image-url';
 import { defaultFormatTimeStamp } from '@/utils/format-date-timestamp';
@@ -23,6 +24,7 @@ interface ThreadFrameProps {
   date: string;
   image?: string;
   isWriter?: boolean;
+  profileId: number;
   tags: Tag[];
   threadContent: string;
   threadId: number;
@@ -30,7 +32,18 @@ interface ThreadFrameProps {
   writerName: string;
 }
 
-export default function ThreadFrame({ isWriter = true, threadContent, writerName, writerIcon, tags, image, threadId, contentId, date }: ThreadFrameProps) {
+export default function ThreadFrame({
+  isWriter = true,
+  threadContent,
+  writerName,
+  writerIcon,
+  tags,
+  image,
+  threadId,
+  contentId,
+  date,
+  profileId,
+}: ThreadFrameProps) {
   const router = useRouter();
 
   const { isOpen: isModalOpen, openModal, closeModal } = useModal();
@@ -62,10 +75,10 @@ export default function ThreadFrame({ isWriter = true, threadContent, writerName
   return (
     <div className={s.threadFrame}>
       <div className={s.threadHeader}>
-        <div className={s.writerInfo}>
+        <button className={s.writerInfo} type="button" onClick={() => router.push(ROUTES.otherProfile(profileId))} aria-label="프로필 보기">
           <div className={s.writerIcon}>{writerIcon && <Image src={writerIcon} alt="writer-icon" width={40} height={40} />}</div>
           <div className={s.writerName}>{writerName}</div>
-        </div>
+        </button>
         {isWriter && (
           <ContentsDropdownActionMenu
             actionItems={[

--- a/src/pages/content/[contentId]/index.tsx
+++ b/src/pages/content/[contentId]/index.tsx
@@ -52,6 +52,7 @@ export default function DetailPage() {
                 threadId={thread.threadId}
                 contentId={contentId}
                 date={thread.createdAt}
+                profileId={thread.profileThreadDto.profileId}
               />
             ))}
           <AddThreadBtn contentId={contentId} />

--- a/src/pages/profile/[id]/index.tsx
+++ b/src/pages/profile/[id]/index.tsx
@@ -1,0 +1,70 @@
+import { type ReactNode, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import { ROUTES } from '@/constants/router';
+
+import { checkValidImgUrl } from '@/utils/check-valid-image-url';
+
+import useGetOtherProfile from '@/hooks/profile/use-get-other-profile';
+
+import ProfileLayout from '@/components/layouts/profile-layout';
+import LottieLoading from '@/components/lottie-loading';
+import NavBar from '@/components/nav-bar';
+
+import NavItem from '../(components)/nav-item';
+import ProfileHeader from '../(components)/profile-header';
+
+import s from '../style.module.scss';
+
+import { DefaultProfile, GroupProfileIcon } from '@/assets/icons';
+
+export default function Profile() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data: profile } = useGetOtherProfile(Number(id));
+
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 내 프로필일 경우
+  useEffect(() => {
+    if (profile?.editable) {
+      void router.push(ROUTES.profile);
+    } else {
+      setIsLoading(false);
+    }
+  }, [profile, router]);
+
+  if (isLoading) {
+    return (
+      <div className={s.profileContainer}>
+        <LottieLoading />
+      </div>
+    );
+  }
+
+  return (
+    <div className={s.profileContainer}>
+      <ProfileHeader text="프로필" iconClick={() => router.back()} />
+      <main>
+        <div className={s.profileWrapper}>
+          {profile?.imageUrl && checkValidImgUrl(profile?.imageUrl) ? <img src={profile?.imageUrl} alt="profile img" /> : <DefaultProfile />}
+          <div className={s.userInfoWrapper}>
+            <div>{profile?.nickname}</div>
+            <p>{profile?.selfIntroduction ?? '한 줄 소개가 없습니다'}</p>
+          </div>
+        </div>
+        <nav className={s.navWrapper}>
+          <NavItem leftIcon={<GroupProfileIcon />} text="팔로워 수" rightIcon={<p>{profile?.followerNum} 명</p>} />
+          <NavItem leftIcon={<GroupProfileIcon />} text="팔로잉" rightIcon={<p>{profile?.followingNum} 명</p>} />
+        </nav>
+      </main>
+    </div>
+  );
+}
+
+Profile.getLayout = (page: ReactNode) => (
+  <ProfileLayout>
+    {page}
+    <NavBar />
+  </ProfileLayout>
+);

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -23,7 +23,7 @@ import s from './style.module.scss';
 
 import { ArrowDownIcon, ArrowUpIcon, ArticleIcon, DefaultProfile, ForwardIcon, PersonIcon } from '@/assets/icons';
 
-export default function Profile() {
+export default function MyProfile() {
   const router = useRouter();
   const [openContents, setOpenContents] = useState<boolean>(false);
   const { data, isPending, fetchNextPage, hasNextPage, isError } = useGetMyContents({ open: openContents });
@@ -108,7 +108,7 @@ export default function Profile() {
   );
 }
 
-Profile.getLayout = (page: ReactNode) => (
+MyProfile.getLayout = (page: ReactNode) => (
   <ProfileLayout>
     {page}
     <NavBar />

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,4 +1,5 @@
 export interface Profile {
+  editable: boolean;
   followerNum: number;
   followingNum: number;
   imageUrl: string;


### PR DESCRIPTION
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다. -->

#116 
  
## ✨ 작업 내용
<!-- 어떤 작업을 하셨는지 내용을 작성해주세요. -->
<!-- 작업된 화면이나 작업 전 후의 비교 이미지가 있으면 더더욱 좋아요. -->

- [x] content에서 프로필 클릭 시, thread에서 프로필 클릭 시 프로필 화면으로 넘어갑니다. (버튼으로 변경해두었습니다)
- [x] 내 프로필 일 경우 profile/:id 에서 profile로 이동해 수정이 가능하게 됩니다. 

 
  
## 💁‍♀️ 참고 사항
<!-- 작업하면서 참고하셨던 사항이 있거나, 읽으셨던 문서 등이 있으셨다면 여기에 남겨주세요. -->
<!-- 동료들에게 좋은 지식을 전파할 수 있는 기회에요 :D -->

원래 팔로잉 팔로워 기능이 없어 이 부분을 나타내는걸 삭제하려했는데,
상대방이 쓴 글 조회 api 는 없고, 수정도 가능한게 아니라 너무 텅텅 비는 것 같아 일단 추가해두었는데 
빼기를 원하시면 주석처리 하겠습니다 
<img width="200" alt="스크린샷 2024-10-04 02 20 23" src="https://github.com/user-attachments/assets/5495f2a3-e0c3-4f94-a2c2-96c284a8949d">
다른 사람의 프로필 확인시 나타나는 화면입니다

  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->

  


  
