### PR TITLE
[Bug] 메인 페이지 내 무한 스크롤 접점 부분에 마진이 없거나 다음 페이지가 1개 뿐일때 프레임이 화면 가득 차지하는 문제

### DIFF
--- a/src/components/feed-grid/style.module.scss
+++ b/src/components/feed-grid/style.module.scss
@@ -1,7 +1,9 @@
 .feedWrapper {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(calc(50% - 4px), 1fr));
+  // grid-template-columns: repeat(auto-fit, minmax(calc(50% - 4px), 1fr));
+  grid-template-columns: calc(50% - 4px) calc(50% - 4px);
   gap: 14px 8px;
   overflow-y: auto;
   width: 100%;
+  margin-bottom: 14px;
 }


### PR DESCRIPTION
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다. -->
[[Bug] 메인 페이지 내 무한 스크롤 접점 부분에 마진이 없거나 다음 페이지가 1개 뿐일때 프레임이 화면 가득 차지하는 문제 #140](https://github.com/Spoon-Lab/our-journey-fe/issues/140)
  
## ✨ 작업 내용
<!-- 어떤 작업을 하셨는지 내용을 작성해주세요. -->
<!-- 작업된 화면이나 작업 전 후의 비교 이미지가 있으면 더더욱 좋아요. -->
- 페이지 간격별 margin-bottom이 누락된 부분을 수정했습니다.
- 글 1개만 있을 경우에 컨텐츠 사이즈가 전체를 받지 않도록 수정했습니다.

## 💁‍♀️ 참고 사항
<!-- 작업하면서 참고하셨던 사항이 있거나, 읽으셨던 문서 등이 있으셨다면 여기에 남겨주세요. -->
<!-- 동료들에게 좋은 지식을 전파할 수 있는 기회에요 :D -->

## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->